### PR TITLE
Fix unwritable paths in pipeline deploy step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,4 +11,5 @@ steps:
     commands:
       - nix-build release.nix
       - mkdir -p ~/cd/serokell-stackage/
+      - chmod -R u+w ~/cd/serokell-stackage/
       - cp -LRf result/* ~/cd/serokell-stackage/


### PR DESCRIPTION
Deploy step was failing because it cannot overwrite existing files: https://buildkite.com/serokell/serokell-stackage/builds/11#3dbd3e23-ee37-4c4e-ac87-8be480dceb4f